### PR TITLE
refactor: updates after project renaming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN poetry build
 # -----
 FROM python:3.9.7-slim-buster
 
-LABEL org.opencontainers.image.source=https://github.com/okp4/template-python-project
+LABEL org.opencontainers.image.source=https://github.com/okp4/template-python
 
 COPY --from=builder /build/dist/*.whl /tmp/whl/
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This way, the template promotes:
 
 > 🚨 do not fork this repository as it is a [template repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template)
 
-1. Click on [Use this template](https://github.com/rochacbruno/python-project-template/generate)
+1. Click on [Use this template](https://github.com/okp4/template-python/generate)
 2. Give a name to your project
 3. Wait until the first run of CI finishes
 4. Clone your new project and happy coding!


### PR DESCRIPTION
The project has been renamed from `template-python-project` to `template-python` to be consistent with the naming of our other templates (i.e.  [template-go](github.com/okp4/template-go), [template-rust](https://github.com/okp4/template-rust)).

This PR makes the needed adjustments as a result of this change.