### PR TITLE
fix(dockerfile): bump curl version to 7.64.0-4+deb10u3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN  apt-get update \
   && apt-get install --no-install-recommends -y \
     build-essential=12.6 \
-    curl=7.64.0-4+deb10u2 \
+    curl=7.64.0-4+deb10u3 \
   && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python \
   && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
   && apt-get clean -y  \


### PR DESCRIPTION
As described in the action logs, the curl version needs to be updated to 7.64.0-4+deb10u3.
`curl : Depends: libcurl4 (= 7.64.0-4+deb10u2) but 7.64.0-4+deb10u3 is to be installed`