### PR TITLE
ci: integrate poetry for mypy lint in CI pipeline

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,9 +70,8 @@ jobs:
           poetry run flake8 --count --show-source --statistics
 
       - name: Lint python code (mypy)
-        uses: jpetrucciani/mypy-check@0.971
-        with:
-          path: "."
+        run: |
+          poetry run mypy .
 
   lint-dockerfile:
     runs-on: ubuntu-22.04

--- a/src/my_app/main.py
+++ b/src/my_app/main.py
@@ -1,22 +1,19 @@
 import click
 
-import my_app.__init__ as init
+from my_app import __init__ as init
 from my_app.hello_world import say_hi
 
 
-@click.group()
-def cli():
-    """OKP4 python template, program description."""
-    pass
+cli = click.Group()
 
 
-@cli.command
-def version():
+@cli.command("version")
+def print_version():
     """Print the application version information"""
     click.echo(init.__version__)
 
 
-@cli.command
+@cli.command("main_cmd")
 @click.option(
     "-n",
     "--name",


### PR DESCRIPTION
Previously, we were using a linter based on `mypy 0.971`, while we are currently on version `1.4`. 
With the help of Poetry, we can also execute the workflow, making it more coherent since we rely on Poetry to build our services.

This modification required me to add an `__init__.py` file in the `src` directory and provide a name for the `click command()` decorator, otherwise Mypy throws errors.
